### PR TITLE
fix(README): Use underscored name for PLUGINS config

### DIFF
--- a/{{cookiecutter.hyphenated}}/README.md
+++ b/{{cookiecutter.hyphenated}}/README.md
@@ -40,11 +40,11 @@ Enable the plugin in `/opt/netbox/netbox/netbox/configuration.py`,
 
 ```python
 PLUGINS = [
-    '{{ cookiecutter.hyphenated }}'
+    '{{ cookiecutter.underscored }}'
 ]
 
 PLUGINS_CONFIG = {
-    "{{ cookiecutter.hyphenated }}": {},
+    "{{ cookiecutter.underscored }}": {},
 }
 ```
 


### PR DESCRIPTION
Revises the plugin name format in README.md to use underscores instead of hyphens in `PLUGINS` and `PLUGINS_CONFIG`.

Fixes #20