### PR TITLE
fix(mkdocs): Correct watch path config in mkdocs

### DIFF
--- a/{{cookiecutter.hyphenated}}/mkdocs.yml
+++ b/{{cookiecutter.hyphenated}}/mkdocs.yml
@@ -47,9 +47,8 @@ plugins:
   - include-markdown
   - search:
       lang: en
-  - mkdocstrings:
-      watch:
-        - {{ cookiecutter.hyphenated }}
+watch:
+  - {{ cookiecutter.underscored }}
 extra:
   social:
     - icon: fontawesome/brands/twitter


### PR DESCRIPTION
This commit fixes the configuration of the watch path in mkdocs. The 'watch' configuration previously supported by mkdocstrings is now integrated into mkdocs. The directory referencing has been fixed by using underscores instead of hyphens. This change will ensure the compatibility of mkdocs with the mkdocstrings plugin.

Fixes #21