### PR TITLE
fix(mkdocs): Correct slugify function in mkdocs.yml

### DIFF
--- a/{{cookiecutter.hyphenated}}/mkdocs.yml
+++ b/{{cookiecutter.hyphenated}}/mkdocs.yml
@@ -41,7 +41,7 @@ markdown_extensions:
   - toc:
       baselevel: 2
       permalink: true
-      slugify: !!python/name:pymdownx.slugs.uslugify
+      slugify: !!python/object/apply:pymdownx.slugs.slugify {}
   - meta
 plugins:
   - include-markdown


### PR DESCRIPTION
Update slugify configuration to use pymdownx's slugify method.
(DeprecationWarning: 'uslugify' is deprecated.)

Fixes #22