### PR TITLE
chore(editorconfig): Add YAML settings

### DIFF
--- a/{{cookiecutter.hyphenated}}/.editorconfig
+++ b/{{cookiecutter.hyphenated}}/.editorconfig
@@ -1,4 +1,4 @@
-# http://editorconfig.org
+# https://editorconfig.org
 
 root = true
 
@@ -13,6 +13,9 @@ end_of_line = lf
 [*.bat]
 indent_style = tab
 end_of_line = crlf
+
+[{*.yml,*.yaml}]
+indent_size = 2
 
 [LICENSE]
 insert_final_newline = false


### PR DESCRIPTION
Change URL protocol to HTTPS in .editorconfig file. Add YAML specific settings to enforce 2 spaces for indentation.

Fixes #28